### PR TITLE
Fixed encoding issue

### DIFF
--- a/src/core/tapcore.py
+++ b/src/core/tapcore.py
@@ -79,7 +79,7 @@ def decryptAES(data):
     
         # one-liners to encrypt/encode and decrypt/decode a string
         # encrypt with AES, encode with base64
-        DecodeAES = lambda c, e: c.decrypt(base64.b64decode(e)).rstrip(PADDING)
+        DecodeAES = lambda c, e: c.decrypt(base64.b64decode(e)).rstrip(PADDING.encode('utf-8'))
         fileopen = open("/root/.tap/store", "r")
         key = fileopen.read()
         secret = base64.b64decode(key)


### PR DESCRIPTION
This small change fixes this traceback

```
[!] Could not establish a connection, printing error:                                                            
a bytes-like object is required, not 'str'                                                                       
^CTraceback (most recent call last):                                                                             
  File "tap.py", line 53, in <module>                                                                            
    ssh_run()                                                                                                    
  File "/home/<user>/tap/src/core/tapcore.py", line 208, in ssh_run                                               
    password = decryptAES(password).rstrip()                                                                     
  File "/home/<user>/tap/src/core/tapcore.py", line 87, in decryptAES                                             
    aes = DecodeAES(cipher, data)                                                                                
  File "/home/<user>/tap/src/core/tapcore.py", line 82, in <lambda>                                               
    DecodeAES = lambda c, e: c.decrypt(base64.b64decode(e)).rstrip(PADDING)                                      
TypeError: a bytes-like object is required, not 'str'                                                            
                                                                                                                 
During handling of the above exception, another exception occurred:                                              
                                                                                                                 
Traceback (most recent call last):                                                                               
  File "tap.py", line 63, in <module>                                                                            
    time.sleep(3)                                                                                                
KeyboardInterrupt
```

The problem is withing the `rstrip` function on line 82 that doesn't fully parse out the encrypted password when using key+password setup through the tap installer.

This issue is only known of on Ubuntu 20.04